### PR TITLE
Add shift+select example

### DIFF
--- a/src/ItemRow.ts
+++ b/src/ItemRow.ts
@@ -1,0 +1,16 @@
+import { TreeViewItem } from "./TreeViewItem";
+
+export interface ItemRow<T extends TreeViewItem> {
+  item: T;
+  depth: number;
+}
+
+export function getItemRows<T extends TreeViewItem>(
+  item: T,
+  depth: number
+): ItemRow<T>[] {
+  return [
+    { item, depth },
+    ...item.children.flatMap((child) => getItemRows(child, depth + 1)),
+  ];
+}

--- a/src/TreeView.tsx
+++ b/src/TreeView.tsx
@@ -26,7 +26,13 @@ function TreeRow<T extends TreeViewItem>({
       onDrop={state.onRowDrop.bind(state, index)}
       onDragOver={state.onRowDragOver.bind(state, index)}
     >
-      {state.props.renderRow({ item, depth, indentation: state.indentation })}
+      {state.props.renderRow({
+        rows: state.rows,
+        index: index,
+        item,
+        depth,
+        indentation: state.indentation,
+      })}
     </div>
   );
 }

--- a/src/TreeViewProps.ts
+++ b/src/TreeViewProps.ts
@@ -1,6 +1,6 @@
 import React from "react";
 import { TreeViewItem } from "./TreeViewItem";
-import { ItemRow } from "./TreeViewState";
+import { ItemRow } from "./ItemRow";
 
 export interface TreeViewProps<T extends TreeViewItem> {
   rootItem: T;

--- a/src/TreeViewProps.ts
+++ b/src/TreeViewProps.ts
@@ -1,5 +1,6 @@
 import React from "react";
 import { TreeViewItem } from "./TreeViewItem";
+import { ItemRow } from "./TreeViewState";
 
 export interface TreeViewProps<T extends TreeViewItem> {
   rootItem: T;
@@ -18,6 +19,8 @@ export interface TreeViewProps<T extends TreeViewItem> {
   onBackgroundClick?: () => void;
 
   renderRow: (params: {
+    rows: readonly ItemRow<T>[];
+    index: number;
     item: T;
     depth: number;
     indentation: number;

--- a/src/TreeViewState.ts
+++ b/src/TreeViewState.ts
@@ -3,25 +3,9 @@ import { TypedEmitter } from "tiny-typed-emitter";
 import { TreeViewItem } from "./TreeViewItem";
 import { assertNonNull, first } from "./utils";
 import { TreeViewProps } from "./TreeViewProps";
+import { getItemRows, ItemRow } from "./ItemRow";
 
 const DRAG_MIME = "application/x.react-draggable-tree-drag";
-
-//// ItemRow
-
-export interface ItemRow<T extends TreeViewItem> {
-  item: T;
-  depth: number;
-}
-
-function getItemRows<T extends TreeViewItem>(
-  item: T,
-  depth: number
-): ItemRow<T>[] {
-  return [
-    { item, depth },
-    ...item.children.flatMap((child) => getItemRows(child, depth + 1)),
-  ];
-}
 
 export type DropIndication =
   | {

--- a/src/stories/TreeView.stories.tsx
+++ b/src/stories/TreeView.stories.tsx
@@ -2,6 +2,7 @@ import { loremIpsum } from "lorem-ipsum";
 import React, { useState } from "react";
 import styled from "styled-components";
 import { TreeView, TreeViewItem } from "../react-draggable-tree";
+import { ItemRow } from "../TreeViewState";
 import { Node } from "./Node";
 
 function generateNode(
@@ -50,11 +51,13 @@ function createItem(node: Node, parent?: NodeTreeViewItem): NodeTreeViewItem {
 }
 
 const TreeRow: React.FC<{
+  rows: readonly ItemRow<NodeTreeViewItem>[];
+  index: number;
   node: Node;
   depth: number;
   indentation: number;
   onChange: () => void;
-}> = ({ node, depth, indentation, onChange }) => {
+}> = ({ rows, index, node, depth, indentation, onChange }) => {
   const onCollapseButtonClick = (e: React.MouseEvent<HTMLElement>) => {
     e.stopPropagation();
     node.collapsed = !node.collapsed;
@@ -62,7 +65,21 @@ const TreeRow: React.FC<{
   };
 
   const onClick = (event: React.MouseEvent<HTMLElement>) => {
-    // TODO: shift + click
+    if (event.shiftKey) {
+      let minSelectedIndex = index;
+      let maxSelectedIndex = index;
+
+      for (const [i, row] of rows.entries()) {
+        if (row.item.node.selected) {
+          minSelectedIndex = Math.min(minSelectedIndex, i);
+          maxSelectedIndex = Math.max(maxSelectedIndex, i);
+        }
+      }
+
+      for (let i = minSelectedIndex; i <= maxSelectedIndex; ++i) {
+        rows[i].item.node.select();
+      }
+    }
 
     if (!(event.metaKey || event.shiftKey)) {
       node.root.deselect();
@@ -169,8 +186,10 @@ export const Basic: React.FC = () => {
             update();
           }
         }}
-        renderRow={({ item, depth, indentation }) => (
+        renderRow={({ rows, index, item, depth, indentation }) => (
           <TreeRow
+            rows={rows}
+            index={index}
             node={item.node}
             depth={depth}
             indentation={indentation}
@@ -243,8 +262,10 @@ export const NonReorderable: React.FC = () => {
             update();
           }
         }}
-        renderRow={({ item, depth, indentation }) => (
+        renderRow={({ rows, index, item, depth, indentation }) => (
           <TreeRow
+            rows={rows}
+            index={index}
             node={item.node}
             depth={depth}
             indentation={indentation}

--- a/src/stories/TreeView.stories.tsx
+++ b/src/stories/TreeView.stories.tsx
@@ -2,7 +2,7 @@ import { loremIpsum } from "lorem-ipsum";
 import React, { useState } from "react";
 import styled from "styled-components";
 import { TreeView, TreeViewItem } from "../react-draggable-tree";
-import { ItemRow } from "../TreeViewState";
+import { ItemRow } from "../ItemRow";
 import { Node } from "./Node";
 
 function generateNode(

--- a/src/stories/TreeView.stories.tsx
+++ b/src/stories/TreeView.stories.tsx
@@ -65,7 +65,14 @@ const TreeRow: React.FC<{
   };
 
   const onClick = (event: React.MouseEvent<HTMLElement>) => {
-    if (event.shiftKey) {
+    if (event.metaKey) {
+      console.log("metaKey");
+      if (node.selected) {
+        node.deselect();
+      } else {
+        node.select();
+      }
+    } else if (event.shiftKey) {
       let minSelectedIndex = index;
       let maxSelectedIndex = index;
 
@@ -79,12 +86,11 @@ const TreeRow: React.FC<{
       for (let i = minSelectedIndex; i <= maxSelectedIndex; ++i) {
         rows[i].item.node.select();
       }
+    } else {
+      node.root.deselect();
+      node.select();
     }
 
-    if (!(event.metaKey || event.shiftKey)) {
-      node.root.deselect();
-    }
-    node.select();
     onChange();
   };
 

--- a/src/stories/TreeView.stories.tsx
+++ b/src/stories/TreeView.stories.tsx
@@ -53,11 +53,13 @@ function createItem(node: Node, parent?: NodeTreeViewItem): NodeTreeViewItem {
 const TreeRow: React.FC<{
   rows: readonly ItemRow<NodeTreeViewItem>[];
   index: number;
-  node: Node;
+  item: NodeTreeViewItem;
   depth: number;
   indentation: number;
   onChange: () => void;
-}> = ({ rows, index, node, depth, indentation, onChange }) => {
+}> = ({ rows, index, item, depth, indentation, onChange }) => {
+  const node = item.node;
+
   const onCollapseButtonClick = (e: React.MouseEvent<HTMLElement>) => {
     e.stopPropagation();
     node.collapsed = !node.collapsed;
@@ -192,16 +194,7 @@ export const Basic: React.FC = () => {
             update();
           }
         }}
-        renderRow={({ rows, index, item, depth, indentation }) => (
-          <TreeRow
-            rows={rows}
-            index={index}
-            node={item.node}
-            depth={depth}
-            indentation={indentation}
-            onChange={update}
-          />
-        )}
+        renderRow={(props) => <TreeRow {...props} onChange={update} />}
       />
     </Wrap>
   );
@@ -268,16 +261,7 @@ export const NonReorderable: React.FC = () => {
             update();
           }
         }}
-        renderRow={({ rows, index, item, depth, indentation }) => (
-          <TreeRow
-            rows={rows}
-            index={index}
-            node={item.node}
-            depth={depth}
-            indentation={indentation}
-            onChange={update}
-          />
-        )}
+        renderRow={(props) => <TreeRow {...props} onChange={update} />}
       />
     </Wrap>
   );

--- a/src/stories/TreeView.stories.tsx
+++ b/src/stories/TreeView.stories.tsx
@@ -68,7 +68,6 @@ const TreeRow: React.FC<{
 
   const onClick = (event: React.MouseEvent<HTMLElement>) => {
     if (event.metaKey) {
-      console.log("metaKey");
       if (node.selected) {
         node.deselect();
       } else {


### PR DESCRIPTION
* Pass `rows` and `index` to `renderRow` callback
  * `rows`: rendered row list
  * `index`: current row index
  * can be used to implement shift-select to select many rows or rounded selections where borders between consecutive selected rows should not be rounded
* Add shift-select example